### PR TITLE
Update compensation request issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,11 +1,21 @@
-## Basic information
+## Summary
 
-> _Specify the amount of BSQ you are requesting, and the BSQ address that amount should be paid to:_
+> _Specify the total amount of BSQ you are requesting, and the BSQ address that amount should be paid to:_
 
- - BSQ amount requested: 
- - BSQ address: 
+ - BSQ requested:
+ - BSQ address:
 
-## Details
 
-> _Provide links to the work you are requesting compensation for, along with any comments or explanations that will help stakeholders understand its value._
+## Contributions delivered
 
+> _Provide links to contributions you have [delivered](https://github.com/bisq-network/proposals/issues/19), the amount of BSQ you are requesting for each, and any comments that will help stakeholders understand its value._
+
+
+## Contributions in progress
+
+> _Provide links to work you're involved with that is still [in progress](https://github.com/bisq-network/proposals/issues/19). **This section is optional,** and is for your own benefit in keeping track of what you're doing and keeping other contributors up to date with the same._
+
+
+## Roles performed
+
+> _Provide links to your [monthly report](https://github.com/bisq-network/proposals/issues/13) on any roles you are responsible for._


### PR DESCRIPTION
This change updates the compensation request issue template to reflect
the sections I used in my request last month at #68. It more clearly
distinguishes between delivered work and works in progress and calls out
a separate section for roles performed.

The goal is that this change is being made in time for most
@bisq-network/contributors who intend to submit compensation requests
for the June 1st–3rd voting round at #70 (several have already
submitted, and so will miss this template change, but can adapt
their existing requests accordingly if they like).